### PR TITLE
Add reusable modal component and showcase home usage

### DIFF
--- a/frontend/src/components/Modal.vue
+++ b/frontend/src/components/Modal.vue
@@ -1,0 +1,197 @@
+<template>
+  <Teleport to="body">
+    <transition name="modal-fade">
+      <div
+        v-if="modelValue"
+        class="modal-overlay"
+        role="presentation"
+        @click="onBackdrop"
+      >
+        <div
+          class="modal-container"
+          role="dialog"
+          :aria-modal="true"
+          :aria-label="computedAriaLabel"
+          @click.stop
+        >
+          <header v-if="$slots.header || title" class="modal-header">
+            <slot name="header">
+              <h2 class="modal-title">{{ title }}</h2>
+            </slot>
+            <button
+              type="button"
+              class="modal-close"
+              aria-label="Close dialog"
+              @click="close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </header>
+
+          <section class="modal-body">
+            <slot />
+          </section>
+
+          <footer v-if="$slots.footer" class="modal-footer">
+            <slot name="footer" />
+          </footer>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { Teleport, computed, onBeforeUnmount, onMounted, watch } from 'vue'
+
+const props = defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+  closeOnBackdrop: {
+    type: Boolean,
+    default: true,
+  },
+  ariaLabel: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['update:modelValue', 'close'])
+
+let previousOverflow = ''
+
+const computedAriaLabel = computed(() => props.ariaLabel || props.title || 'Dialog')
+
+const close = () => {
+  emit('update:modelValue', false)
+  emit('close')
+}
+
+const onBackdrop = () => {
+  if (props.closeOnBackdrop) {
+    close()
+  }
+}
+
+const onKeydown = (event) => {
+  if (event.key === 'Escape' && props.modelValue) {
+    close()
+  }
+}
+
+const lockScroll = () => {
+  previousOverflow = document.body.style.overflow
+  document.body.style.overflow = 'hidden'
+}
+
+const restoreScroll = () => {
+  document.body.style.overflow = previousOverflow || ''
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+  restoreScroll()
+})
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (typeof window === 'undefined') return
+    if (value) {
+      lockScroll()
+    } else {
+      restoreScroll()
+    }
+  }
+)
+</script>
+
+<style scoped>
+.modal-fade-enter-active,
+.modal-fade-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.modal-fade-enter-from,
+.modal-fade-leave-to {
+  opacity: 0;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.58);
+  backdrop-filter: blur(6px);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal-container {
+  width: min(560px, 100%);
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 32px 64px rgba(15, 23, 42, 0.25);
+  display: grid;
+  gap: 1.25rem;
+  padding: 2rem;
+  position: relative;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #0f172a;
+}
+
+.modal-close {
+  border: none;
+  background: transparent;
+  color: #64748b;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 150ms ease, transform 150ms ease;
+}
+
+.modal-close:hover {
+  color: #1d4ed8;
+  transform: scale(1.05);
+}
+
+.modal-body {
+  color: #475569;
+  line-height: 1.7;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+@media (max-width: 520px) {
+  .modal-container {
+    padding: 1.5rem;
+  }
+}
+</style>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -6,12 +6,47 @@
       better decisions. Explore our work, learn about our services, and connect
       with us to see how we can collaborate.
     </p>
-    <RouterLink class="cta" to="/contact">Let's work together</RouterLink>
+    <div class="home-actions">
+      <RouterLink class="cta" to="/contact">Let's work together</RouterLink>
+      <button type="button" class="ghost-cta" @click="openModal">Learn more</button>
+    </div>
+
+    <Modal v-model="showAboutModal" title="How we partner with teams">
+      <p>
+        Every project starts with understanding your goals. We combine discovery
+        workshops, rapid prototyping, and tight feedback loops to craft products
+        that feel effortless to use. Our cross-functional team guides you from
+        idea to launch and beyond.
+      </p>
+      <p>
+        Ready to see what we can build together? Reach out and we'll shape a
+        roadmap tailored to your team.
+      </p>
+
+      <template #footer>
+        <button type="button" class="modal-secondary" @click="closeModal">Not yet</button>
+        <RouterLink class="modal-primary" to="/contact" @click="closeModal">
+          Start a project
+        </RouterLink>
+      </template>
+    </Modal>
   </section>
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import { RouterLink } from 'vue-router'
+import Modal from '../components/Modal.vue'
+
+const showAboutModal = ref(false)
+
+const openModal = () => {
+  showAboutModal.value = true
+}
+
+const closeModal = () => {
+  showAboutModal.value = false
+}
 </script>
 
 <style scoped>
@@ -35,6 +70,13 @@ import { RouterLink } from 'vue-router'
   line-height: 1.7;
 }
 
+.home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+
 .cta {
   display: inline-flex;
   align-items: center;
@@ -52,5 +94,58 @@ import { RouterLink } from 'vue-router'
 .cta:hover {
   transform: translateY(-2px);
   box-shadow: 0 18px 36px rgba(37, 99, 235, 0.45);
+}
+
+.ghost-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease;
+}
+
+.ghost-cta:hover {
+  background: rgba(37, 99, 235, 0.12);
+  border-color: rgba(37, 99, 235, 0.55);
+}
+
+.modal-primary,
+.modal-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.modal-primary {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.35);
+  border: none;
+  cursor: pointer;
+}
+
+.modal-primary:hover {
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.45);
+}
+
+.modal-secondary {
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: #f8fafc;
+  color: #475569;
+  cursor: pointer;
+}
+
+.modal-secondary:hover {
+  border-color: rgba(100, 116, 139, 0.8);
 }
 </style>


### PR DESCRIPTION
## Summary
- add a reusable modal component with slot-based content, accessibility hooks, and scroll locking
- integrate the modal into the home page with a secondary call-to-action and supporting styles

## Testing
- npm run build *(fails: missing npm registry access for vue-router)*

------
https://chatgpt.com/codex/tasks/task_e_68db7cc7989c8331aad6a34c6614db58