### PR TITLE
Add authenticated dashboard and login flow

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,14 @@
 <script setup>
-import { RouterLink, RouterView } from 'vue-router'
+import { RouterLink, RouterView, useRouter } from 'vue-router'
+import { useAuth } from './stores/auth.js'
+
+const router = useRouter()
+const { user, isAuthenticated, logout } = useAuth()
+
+const handleLogout = () => {
+  logout()
+  router.push('/')
+}
 </script>
 
 <template>
@@ -10,6 +19,12 @@ import { RouterLink, RouterView } from 'vue-router'
         <div class="nav-links">
           <RouterLink to="/">Home</RouterLink>
           <RouterLink to="/contact">Contact</RouterLink>
+          <RouterLink v-if="isAuthenticated" to="/dashboard">Dashboard</RouterLink>
+          <span v-if="isAuthenticated" class="user-pill">Hi, {{ user?.name }}</span>
+          <button v-if="isAuthenticated" type="button" class="logout-button" @click="handleLogout">
+            Log out
+          </button>
+          <RouterLink v-else to="/login" class="login-link">Log in</RouterLink>
         </div>
       </nav>
     </header>
@@ -70,6 +85,45 @@ import { RouterLink, RouterView } from 'vue-router'
 .nav-links a.router-link-exact-active {
   background: rgba(255, 255, 255, 0.2);
   color: #fff;
+}
+
+.user-pill {
+  display: none;
+}
+
+.logout-button {
+  border: none;
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.logout-button:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.login-link {
+  font-weight: 600;
+}
+
+@media (min-width: 720px) {
+  .user-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.75rem;
+    background: rgba(15, 23, 42, 0.25);
+    border-radius: 999px;
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 600;
+  }
+
+  .nav-links {
+    gap: 0.75rem;
+  }
 }
 
 .site-content {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,5 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import { isAuthenticated } from '../stores/auth.js'
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -13,10 +15,35 @@ const router = createRouter({
       name: 'contact',
       component: () => import('../views/ContactView.vue'),
     },
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('../views/LoginView.vue'),
+      meta: { guestOnly: true },
+    },
+    {
+      path: '/dashboard',
+      name: 'dashboard',
+      component: () => import('../views/DashboardView.vue'),
+      meta: { requiresAuth: true },
+    },
   ],
   scrollBehavior() {
     return { top: 0 }
   },
+})
+
+router.beforeEach((to) => {
+  if (to.meta?.requiresAuth && !isAuthenticated()) {
+    return {
+      name: 'login',
+      query: { redirect: to.fullPath },
+    }
+  }
+
+  if (to.meta?.guestOnly && isAuthenticated()) {
+    return { name: 'dashboard' }
+  }
 })
 
 export default router

--- a/frontend/src/stores/auth.js
+++ b/frontend/src/stores/auth.js
@@ -1,0 +1,69 @@
+import { reactive, computed } from 'vue'
+
+const STORAGE_KEY = 'acme-auth-user'
+
+function readStoredUser() {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch (error) {
+    console.warn('Failed to read stored user', error)
+    return null
+  }
+}
+
+function persistUser(user) {
+  if (typeof window === 'undefined') return
+  try {
+    if (user) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+    } else {
+      window.localStorage.removeItem(STORAGE_KEY)
+    }
+  } catch (error) {
+    console.warn('Failed to persist user', error)
+  }
+}
+
+const state = reactive({
+  user: readStoredUser(),
+})
+
+function setUser(user) {
+  state.user = user
+  persistUser(user)
+}
+
+export function useAuth() {
+  const login = ({ name, email }) => {
+    if (!email) {
+      throw new Error('Email is required')
+    }
+
+    const safeName = name?.trim() || email.split('@')[0]
+    const user = {
+      name: safeName,
+      email,
+      loggedInAt: new Date().toISOString(),
+    }
+
+    setUser(user)
+    return user
+  }
+
+  const logout = () => {
+    setUser(null)
+  }
+
+  return {
+    user: computed(() => state.user),
+    isAuthenticated: computed(() => Boolean(state.user)),
+    login,
+    logout,
+  }
+}
+
+export function isAuthenticated() {
+  return Boolean(state.user)
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,0 +1,93 @@
+<template>
+  <section class="dashboard">
+    <header>
+      <h1>Hello, {{ formattedName }}!</h1>
+      <p>Here's a quick look at what's happening with your account today.</p>
+    </header>
+
+    <section class="cards">
+      <article class="card">
+        <h2>Projects in progress</h2>
+        <p class="card-number">3</p>
+        <p>Keep up the great work—two milestones are due this week.</p>
+      </article>
+      <article class="card">
+        <h2>New messages</h2>
+        <p class="card-number">5</p>
+        <p>Clients have shared fresh feedback. Take a look when you have a moment.</p>
+      </article>
+      <article class="card">
+        <h2>Upcoming meetings</h2>
+        <p class="card-number">2</p>
+        <p>Your next strategy call kicks off tomorrow at 10:00 AM.</p>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { useAuth } from '../stores/auth.js'
+
+const { user } = useAuth()
+
+const formattedName = computed(() => user.value?.name ?? 'there')
+</script>
+
+<style scoped>
+.dashboard {
+  display: grid;
+  gap: 2.5rem;
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  color: #0f172a;
+}
+
+header p {
+  margin: 0.75rem 0 0;
+  color: #475569;
+  line-height: 1.7;
+}
+
+.cards {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: #ffffff;
+  padding: 1.75rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  color: #1e293b;
+}
+
+.card-number {
+  margin: 0;
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #2563eb;
+}
+
+.card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+@media (min-width: 900px) {
+  .cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+</style>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -1,0 +1,170 @@
+<template>
+  <section class="auth">
+    <header>
+      <h1>Welcome back</h1>
+      <p>Please sign in to access your personalized dashboard.</p>
+    </header>
+
+    <form class="auth-form" @submit.prevent="handleSubmit">
+      <label>
+        Name
+        <input v-model="form.name" type="text" name="name" autocomplete="name" placeholder="Jane Doe" />
+      </label>
+      <label>
+        Email
+        <input
+          v-model="form.email"
+          type="email"
+          name="email"
+          autocomplete="email"
+          required
+          placeholder="you@example.com"
+        />
+      </label>
+      <label>
+        Password
+        <input
+          v-model="form.password"
+          type="password"
+          name="password"
+          autocomplete="current-password"
+          required
+          placeholder="••••••••"
+        />
+      </label>
+      <p v-if="error" class="form-error">{{ error }}</p>
+      <button type="submit">Log in</button>
+    </form>
+
+    <p class="footnote">
+      New to Acme Co.? Reach out via the <RouterLink to="/contact">contact page</RouterLink> to get an account.
+    </p>
+  </section>
+</template>
+
+<script setup>
+import { reactive, ref, watchEffect } from 'vue'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
+import { useAuth } from '../stores/auth.js'
+
+const router = useRouter()
+const route = useRoute()
+const { login, isAuthenticated } = useAuth()
+
+const form = reactive({
+  name: '',
+  email: '',
+  password: '',
+})
+
+const error = ref('')
+
+watchEffect(() => {
+  if (isAuthenticated.value) {
+    router.replace(route.query.redirect?.toString() || '/dashboard')
+  }
+})
+
+const handleSubmit = () => {
+  error.value = ''
+
+  if (!form.email || !form.password) {
+    error.value = 'Please provide both an email and password.'
+    return
+  }
+
+  try {
+    login({ name: form.name, email: form.email })
+    router.push(route.query.redirect?.toString() || '/dashboard')
+  } catch (err) {
+    error.value = err.message || 'Unable to log in right now. Please try again.'
+  }
+}
+</script>
+
+<style scoped>
+.auth {
+  display: grid;
+  gap: 2rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: #0f172a;
+}
+
+header p {
+  margin: 0.75rem 0 0;
+  color: #475569;
+  line-height: 1.7;
+}
+
+.auth-form {
+  display: grid;
+  gap: 1.5rem;
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+}
+
+label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+input {
+  width: 100%;
+  font: inherit;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #f8fafc;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+button {
+  justify-self: start;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.35);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 36px rgba(37, 99, 235, 0.45);
+}
+
+.form-error {
+  margin: -0.5rem 0 0;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+.footnote {
+  margin: 0;
+  color: #475569;
+}
+
+.footnote a {
+  color: #2563eb;
+  font-weight: 600;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a lightweight auth store with localStorage persistence and helper methods
- create a login view and dashboard view, wiring up router guards so the dashboard requires authentication
- surface login/logout controls in the header and keep navigation consistent with the user state

## Testing
- npm run build *(fails: registry access to install vue-router is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db7aab32908331b7955d81e7f98f02